### PR TITLE
Release sebex_test_core v0.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ by adding `sebex_test_core` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-	{:sebex_test_core, "~> 0.6.0"}
+	{:sebex_test_core, "~> 0.7.0"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule SebexTestCore.MixProject do
   use Mix.Project
 
-  @version "0.6.0"
+  @version "0.7.0"
 
   def project do
     [

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "bunch": {:hex, :bunch, "1.4.0", "ba6dc15b346498f4f1be602f505e341ecb2cdc32c1bccb3865fcc3d1f834e987", [:mix], [], "hexpm", "a6e5cff50be7e8fad7d4875bb890abb80d4bcfcdd76553ef29dc978dabd25e85"},
+  "bunch": {:hex, :bunch, "1.4.1", "96176220b2024f715e9e85051f18ee98bbb42be77728a0165cdc3c01c87e483b", [:mix], [], "hexpm", "ff0bb584267f32a1541e7299fefe22a185e269b4081983bd6c5b0d56369f9037"},
   "bunt": {:hex, :bunt, "0.2.1", "e2d4792f7bc0ced7583ab54922808919518d0e57ee162901a16a1b6664ef3b14", [:mix], [], "hexpm", "a330bfb4245239787b15005e66ae6845c9cd524a288f0d141c148b02603777a5"},
   "certifi": {:hex, :certifi, "2.9.0", "6f2a475689dd47f19fb74334859d460a2dc4e3252a3324bd2111b8f0429e7e21", [:rebar3], [], "hexpm", "266da46bdb06d6c6d35fde799bcb28d36d985d424ad7c08b5bb48f5b5cdd4641"},
   "coerce": {:hex, :coerce, "1.0.1", "211c27386315dc2894ac11bc1f413a0e38505d808153367bd5c6e75a4003d096", [:mix], [], "hexpm", "b44a691700f7a1a15b4b7e2ff1fa30bebd669929ac8aa43cffe9e2f8bf051cf1"},


### PR DESCRIPTION
### Release "Early Pretty Stag"

| Project | New Version |
|---|---|
| sebex_test_core | `0.7.0` |
| sebex_test_x | `0.10.0` |


<sup>proudly automated with <a href="https://github.com/membraneframework/sebex">Sebex</a></sup>